### PR TITLE
Created Systemd service

### DIFF
--- a/streamdvr.service
+++ b/streamdvr.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Streamdvr Service
+After=network.target
+
+[Service]
+Type=simple
+User=user #Your Username
+Group=group #Your Group name. Usually same as your username.
+WorkingDirectory=/home/[username]/StreamDVR
+ExecStart=/home/[username]/.nvm/versions/node/v9.11.1/bin/node /home/[username]/StreamDVR/streamdvr.js
+ExecReload=/bin/kill -HUP $MAINPID
+KillSignal=SIGINT
+
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This can be used to run streamdvr in the background in systems that support Systemd (Debian, Ubuntu, etc.)
It also sends an interrupt signal to let all streams finish converting when the stop command is used. 

Change username, group, directory and node location accordingly. 