### PR TITLE
Re-add underscore to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "js-yaml": "^3.13.1",
         "moment": "^2.24.0",
         "mv": "^2.1.1",
-        "neo-blessed": "github:embark-framework/neo-blessed"
+        "neo-blessed": "github:embark-framework/neo-blessed",
+        "underscore": "^1.9.1"
     }
 }


### PR DESCRIPTION
It looks like this may have been accidentally removed in the latest commit. 