### PR TITLE
Update docker image URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ https://en.wikipedia.org/wiki/Sony_Corp._of_America_v._Universal_City_Studios,_I
 
 * Supported sites: Twitch, Youtube, Pixiv, Picarto
 
-* Docker available at https://hub.docker.com/r/purrsevere/streamdvr-docker/
+* Docker available at https://ghcr.io/purrsevere/streamdvr
 
 ### Setup ###
 


### PR DESCRIPTION
Moved image to Github Container Registry since Docker Hub discontinued automated builds for free accounts.