### PR TITLE
Update the required node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ https://en.wikipedia.org/wiki/Sony_Corp._of_America_v._Universal_City_Studios,_I
 
 ### Setup ###
 
-* Dependencies: `bash`, `node.js >= 10.13.0`, `npm`, `git`, and `ffmpeg`
+* Dependencies: `bash`, `node.js >= 14.0.0`, `npm`, `git`, and `ffmpeg`
   * StreamDVR does not work in a windows command prompt.  Use WSL to run StreamDVR in Windows.
 * Optional Dependencies: `streamlink`, `youtube-dl`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
                 "eslint-plugin-unicorn": "^36.0.0"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "DVR for streaming entertainment",
     "main": "streamdvr",
     "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
     },
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Node version 10 (per Readme) or 12 (per package.json) fail to find package `fs/promises`. 14 does work though.  

Apparently it can be solved by doing this:
```
const fsp = require("fs").promises;
```
But I feel like bumping Node is a better option, since the support for LTS 12 is going to end in a few months.